### PR TITLE
Fix "no invalidate" logic in ICache sequence

### DIFF
--- a/dv/uvm/icache/dv/env/seq_lib/ibex_icache_caching_vseq.sv
+++ b/dv/uvm/icache/dv/env/seq_lib/ibex_icache_caching_vseq.sv
@@ -15,8 +15,8 @@ class ibex_icache_caching_vseq extends ibex_icache_base_vseq;
     core_seq.initial_enable     = 1'b1;
     core_seq.const_enable       = 1'b1;
 
-    // Don't invalidate the cache (since that will lower the hit rate)
-    core_seq.no_invalidate = 1'b1;
+    // Try not to invalidate the cache (since that will lower the hit rate)
+    core_seq.avoid_invalidation = 1'b1;
 
   endtask : pre_start
 

--- a/dv/uvm/icache/dv/env/seq_lib/ibex_icache_oldval_vseq.sv
+++ b/dv/uvm/icache/dv/env/seq_lib/ibex_icache_oldval_vseq.sv
@@ -16,8 +16,8 @@ class ibex_icache_oldval_vseq extends ibex_icache_base_vseq;
     // Increase the frequency of cache enable/disable toggling
     core_seq.gap_between_toggle_enable = 2;
 
-    // Don't invalidate the cache (we want old values!)
-    core_seq.no_invalidate = 1'b1;
+    // Avoid invalidating the cache (we want old values!)
+    core_seq.avoid_invalidation = 1'b1;
 
   endtask : pre_start
 

--- a/dv/uvm/icache/dv/ibex_icache_core_agent/seq_lib/ibex_icache_core_base_seq.sv
+++ b/dv/uvm/icache/dv/ibex_icache_core_agent/seq_lib/ibex_icache_core_base_seq.sv
@@ -33,7 +33,7 @@ class ibex_icache_core_base_seq extends dv_base_seq #(
 
   // If this bit is set, we will never invalidate the cache (useful for hit ratio tracking), except
   // if must_invalidate is set.
-  bit no_invalidate = 1'b0;
+  bit avoid_invalidation = 1'b0;
 
   // The expected number of items between each new memory seed when the cache is disabled. A new
   // memory seed when the cache is disabled implies that the next time the cache is enabled, we must
@@ -150,9 +150,8 @@ class ibex_icache_core_base_seq extends dv_base_seq #(
        // If must_invalidate is set, we have to invalidate with this item.
        must_invalidate -> invalidate == 1'b1;
 
-       // If no_invalidate is set, we shouldn't ever touch the invalidate line, unless
-       // must_invalidate is set (which will only apply once).
-       (no_invalidate && !must_invalidate) -> invalidate == 1'b0;
+       // If avoid_invalidation is set, we won't touch the invalidate line, unless we have to.
+       (avoid_invalidation && !(must_invalidate || (stale_seed && enable))) -> invalidate == 1'b0;
 
        // Start an invalidation every 1+gap_between_invalidations items.
        invalidate dist { 1'b0 :/ gap_between_invalidations, 1'b1 :/ 1 };


### PR DESCRIPTION
Some sequences run in "no invalidate" mode. Unfortunately, sometimes
we *have* to invalidate, either because we have a stale seed, or
because we're at the start of a sequence.

It turns out that "no invalidate" is a soft requirement, so we can
weaken it here. This patch also renames the flag to
"avoid_invalidation" to make it clear that this is allowed to be
violated occasionally.

Closes #1101.